### PR TITLE
Port Plurr to Rust 🦀

### DIFF
--- a/rust/.gitignore
+++ b/rust/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+target/
+Cargo.lock

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "plurr"
+version = "0.1.0"
+authors = ["Julen Ruiz Aizpuru <julenx@gmail.com>"]
+edition = "2018"
+description = "A library for handling plurals/genders/conditionals."
+license = "MIT"
+
+
+[dependencies]

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,0 +1,24 @@
+## Plurr
+
+A library for handling plurals/genders/conditionals.
+
+### Installation
+
+Add the `plurr` crate to your *Cargo.toml* file:
+
+```toml
+[dependencies]
+plurr = "0.1.0"
+```
+
+### Usage
+
+```rust
+extern crate plurr;
+
+use plurr::Plurr;
+
+let mut p = Plurr::new();
+let s = "Delete {N_PLURAL:{N} file|{N} files}?";
+p.param("N", "5").format(s); // "Delete 5 files?"
+```

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,0 +1,207 @@
+// Copyright (C) 2020 Julen Ruiz Aizpuru, https://github.com/julen
+
+//! # Plurr
+//!
+//! A library for handling plurals/genders/conditionals.
+
+use std::collections::HashMap;
+
+mod plurals;
+mod utils;
+
+const _PLURAL: &str = "_PLURAL";
+
+#[derive(Debug, PartialEq)]
+pub enum PlurrError {
+    EmptyPlaceholder,
+    EmptyVariants,
+    NotZeroOrPositiveValue,
+    UnmatchedOpeningBrace,
+    UnmatchedClosingBrace,
+    UndefinedParameter,
+    UndefinedParameterPairs,
+}
+
+type PlurrParams = HashMap<String, String>;
+
+#[derive(Debug)]
+pub struct Plurr {
+    locale: String,
+    auto_plurals: bool,
+    strict: bool,
+    params: PlurrParams,
+}
+
+impl Default for Plurr {
+    fn default() -> Self {
+        Plurr::new()
+    }
+}
+
+impl Plurr {
+    pub fn new() -> Self {
+        Plurr {
+            locale: "en".to_string(),
+            auto_plurals: true,
+            strict: true,
+            params: PlurrParams::new(),
+        }
+    }
+
+    /// Sets the locale for Plurr. If this is not called or an incompatible
+    /// `locale_code` is provided, it defaults to English.
+    pub fn locale(&mut self, locale_code: &str) -> &mut Plurr {
+        self.locale = locale_code.to_string();
+        self
+    }
+
+    /// Toggles the auto-plural behavior.
+    /// * With auto-plurals, Plurr will automatically select the plural form for
+    /// the current locale.
+    /// * Without auto-plurals, you will need to manually provide an `N_PLURAL`
+    /// parameter before calling `format()`.
+    pub fn auto_plurals(&mut self, auto_plurals: bool) -> &mut Plurr {
+        self.auto_plurals = auto_plurals;
+        self
+    }
+
+    /// Toggles strict mode. In strict mode, errors are not skipped.
+    pub fn strict(&mut self, strict: bool) -> &mut Plurr {
+        self.strict = strict;
+        self
+    }
+
+    /// Stores a parameter value. Parameters must be fed before calling
+    /// `format()`.
+    pub fn param(&mut self, key: &str, value: &str) -> &mut Plurr {
+        self.params.insert(key.to_string(), value.to_string());
+        self
+    }
+
+    /// Formats a Plurr string and returns the evaluated string.
+    ///
+    /// For the format spec please check out the project
+    /// [README](https://github.com/loctools/plurr/blob/master/README.md).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use plurr::Plurr;
+    ///
+    /// let mut p = Plurr::new();
+    /// let s = "Delete {N_PLURAL:{N} file|{N} files}?";
+    ///
+    /// assert_eq!(
+    ///     p.param("N", "5").format(s),
+    ///     Ok("Delete 5 files?".to_string())
+    /// );
+    /// ```
+    pub fn format(&mut self, value: &str) -> Result<String, PlurrError> {
+        let mut bracket_count = 0;
+        let mut blocks = vec!["".to_string()];
+
+        for chunk in utils::split_string(value, "{", "}") {
+            if chunk == "{" {
+                bracket_count += 1;
+                blocks.push("".to_string());
+                continue;
+            }
+
+            if chunk == "}" {
+                bracket_count -= 1;
+                if bracket_count < 0 {
+                    return Err(PlurrError::UnmatchedClosingBrace);
+                }
+
+                let block = blocks.pop().unwrap();
+                let colon_pos_maybe = block.find(':');
+
+                let name = match colon_pos_maybe {
+                    Some(colon_pos) => {
+                        if self.strict && colon_pos == 0 {
+                            return Err(PlurrError::EmptyPlaceholder);
+                        }
+                        // Multiple choices
+                        block[0..colon_pos].to_string()
+                    }
+                    // Simple placeholder
+                    None => block.to_owned(),
+                };
+
+                if !self.params.contains_key(&name) {
+                    let p_pos = name.find(_PLURAL);
+                    if self.auto_plurals
+                        && p_pos.is_some()
+                        && p_pos.unwrap() == name.len() - _PLURAL.len()
+                    {
+                        let prefix = name[0..p_pos.unwrap()].to_string();
+                        if !self.params.contains_key(&prefix) && self.strict {
+                            return Err(PlurrError::UndefinedParameterPairs);
+                        }
+
+                        // This is where the actual parameter replacing happens
+                        let prefix_value_maybe = self.params.get(&prefix).unwrap();
+                        let prefix_value;
+                        match prefix_value_maybe.parse::<usize>() {
+                            Ok(parsed_value) => prefix_value = parsed_value,
+                            Err(_) => {
+                                if self.strict {
+                                    return Err(PlurrError::NotZeroOrPositiveValue);
+                                }
+                                prefix_value = 0;
+                            }
+                        }
+
+                        self.params.insert(
+                            name.clone(),
+                            plurals::plural_func(&self.locale, prefix_value).to_string(),
+                        );
+                    } else if self.strict {
+                        return Err(PlurrError::UndefinedParameter);
+                    }
+                }
+
+                let result = match colon_pos_maybe {
+                    Some(colon_pos) => {
+                        // multiple choices
+                        let block_len = block.len();
+
+                        if self.strict && colon_pos == block_len - 1 {
+                            return Err(PlurrError::EmptyVariants);
+                        }
+
+                        let value = self.params.get(&name).unwrap();
+                        let mut choice_idx: usize = value.parse().unwrap_or(0);
+
+                        let content_start = colon_pos + 1;
+                        let clean_block = &block[content_start..];
+
+                        let parts: Vec<&str> = clean_block.split('|').collect();
+                        if choice_idx >= parts.len() {
+                            choice_idx = parts.len() - 1;
+                        }
+                        parts[choice_idx]
+                    }
+                    None => self.params.get(&name).unwrap(),
+                };
+
+                let index = blocks.len() - 1;
+                blocks[index].push_str(result);
+
+                continue;
+            }
+
+            let index = blocks.len() - 1;
+            blocks[index].push_str(&chunk);
+        }
+
+        if bracket_count > 0 {
+            return Err(PlurrError::UnmatchedOpeningBrace);
+        }
+
+        // Clear params for subsequent calls
+        self.params.clear();
+
+        Ok(blocks[0].clone())
+    }
+}

--- a/rust/src/plurals.rs
+++ b/rust/src/plurals.rs
@@ -1,0 +1,983 @@
+// Copyright (C) 2020 Julen Ruiz Aizpuru, https://github.com/julen
+
+pub(crate) fn plural_func(locale: &str, n: usize) -> usize {
+    match locale {
+        "ach" => {
+            // Acholi
+            0
+        }
+        "af" => {
+            // Afrikaans
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "ak" => {
+            // Akhan
+            if n > 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "am" => {
+            // Amharic
+            if n > 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "an" => {
+            // Aragonese
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "ar" => {
+            // Arabic
+            if n == 0 {
+                0
+            } else if n == 1 {
+                1
+            } else if n == 2 {
+                2
+            } else if n % 100 >= 3 && n % 100 <= 10 {
+                3
+            } else if n % 100 >= 11 {
+                4
+            } else {
+                5
+            }
+        }
+        "arn" => {
+            // Mapudungun
+            if n > 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "ast" => {
+            // Asturian
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "ay" => {
+            // Aymara
+            0
+        }
+        "az" => {
+            // Azerbaijani
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+
+        "be" => {
+            // Belarusian
+            if n % 10 == 1 && n % 100 != 11 {
+                0
+            } else if n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 10 || n % 100 >= 20) {
+                1
+            } else {
+                2
+            }
+        }
+        "bg" => {
+            // Bulgarian
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "bn" => {
+            // Bengali
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "bo" => {
+            // Tibetan
+            0
+        }
+        "br" => {
+            // Breton
+            if n > 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "bs" => {
+            // Bosnian
+            if n % 10 == 1 && n % 100 != 11 {
+                0
+            } else if n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 10 || n % 100 >= 20) {
+                1
+            } else {
+                2
+            }
+        }
+
+        "ca" => {
+            // Catalan
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "cgg" => {
+            // Chiga
+            0
+        }
+        "cs" => {
+            // Czech
+            if n == 1 {
+                0
+            } else if n >= 2 && n <= 4 {
+                1
+            } else {
+                2
+            }
+        }
+        "csb" => {
+            // Kashubian
+            if n == 1 {
+                0
+            } else if n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 10 || n % 100 >= 20) {
+                1
+            } else {
+                2
+            }
+        }
+        "cy" => {
+            // Welsh
+            if n == 1 {
+                0
+            } else if n == 2 {
+                1
+            } else if n != 8 && n != 11 {
+                2
+            } else {
+                3
+            }
+        }
+
+        "da" => {
+            // Danish
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "de" => {
+            // German
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "dz" => {
+            // Dzongkha
+            0
+        }
+
+        "el" => {
+            // Greek
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "en" => {
+            // English
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "eo" => {
+            // Esperanto
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "es" => {
+            // Spanish
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "es-ar" => {
+            // Argentinean Spanish
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "et" => {
+            // Estonian
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "eu" => {
+            // Basque
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+
+        "fa" => {
+            // Persian
+            0
+        }
+        "fi" => {
+            // Finnish
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "fil" => {
+            // Filipino
+            if n > 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "fo" => {
+            // Faroese
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "fr" => {
+            // French
+            if n > 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "fur" => {
+            // Friulian
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "fy" => {
+            // Frisian
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+
+        "ga" => {
+            // Irish
+            if n == 1 {
+                0
+            } else if n == 2 {
+                1
+            } else if n < 7 {
+                2
+            } else if n < 11 {
+                3
+            } else {
+                4
+            }
+        }
+        "gl" => {
+            // Galician
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "gu" => {
+            // Gujarati
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "gun" => {
+            // Gun
+            if n > 1 {
+                1
+            } else {
+                0
+            }
+        }
+
+        "ha" => {
+            // Hausa
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "he" => {
+            // Hebrew
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "hi" => {
+            // Hindi
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "hy" => {
+            // Armenian
+            0
+        }
+        "hr" => {
+            // Croatian
+            if n % 10 == 1 && n % 100 != 11 {
+                0
+            } else if n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 10 || n % 100 >= 20) {
+                1
+            } else {
+                2
+            }
+        }
+        "hu" => {
+            // Hungarian
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+
+        "ia" => {
+            // Interlingua
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "id" => {
+            // Indonesian
+            0
+        }
+        "is" => {
+            // Icelandic
+            if n % 10 != 1 || n % 100 == 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "it" => {
+            // Italian
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+
+        "ja" => {
+            // Japanese
+            0
+        }
+        "jv" => {
+            // Javanese
+            if n != 0 {
+                1
+            } else {
+                0
+            }
+        }
+
+        "ka" => {
+            // Georgian
+            0
+        }
+        "kk" => {
+            // Kazakh
+            0
+        }
+        "km" => {
+            // Khmer
+            0
+        }
+        "kn" => {
+            // Kannada
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "ko" => {
+            // Korean
+            0
+        }
+        "ku" => {
+            // Kurdish
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "kw" => {
+            // Cornish
+            if n == 1 {
+                0
+            } else if n == 2 {
+                1
+            } else if n == 3 {
+                2
+            } else {
+                3
+            }
+        }
+        "ky" => {
+            // Kyrgyz
+            0
+        }
+
+        "lb" => {
+            // Letzeburgesch
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "ln" => {
+            // Lingala
+            if n > 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "lo" => {
+            // Lao
+            0
+        }
+        "lt" => {
+            // Lithuanian
+            if n % 10 == 1 && n % 100 != 11 {
+                0
+            } else if n % 10 >= 2 && (n % 100 < 10 || n % 100 >= 20) {
+                1
+            } else {
+                2
+            }
+        }
+        "lv" => {
+            // Latvian
+            if n % 10 == 1 && n % 100 != 11 {
+                0
+            } else if n != 0 {
+                1
+            } else {
+                2
+            }
+        }
+
+        "mfe" => {
+            // Mauritian Creole
+            if n > 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "mg" => {
+            // Malagasy
+            if n > 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "mi" => {
+            // Maori
+            if n > 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "mk" => {
+            // Macedonian
+            if n == 1 || n % 10 == 1 {
+                0
+            } else {
+                1
+            }
+        }
+        "ml" => {
+            // Malayalam
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "mn" => {
+            // Mongolian
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "mr" => {
+            // Marathi
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "ms" => {
+            // Malay
+            0
+        }
+        "mt" => {
+            // Maltese
+            if n == 1 {
+                0
+            } else if n == 0 || (n % 100 > 1 && n % 100 < 11) {
+                1
+            } else if n % 100 > 10 && n % 100 < 20 {
+                2
+            } else {
+                3
+            }
+        }
+
+        "nah" => {
+            // Nahuatl
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "nap" => {
+            // Neapolitan
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "nb" => {
+            // Norwegian Bokmal
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "ne" => {
+            // Nepali
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "nl" => {
+            // Dutch
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "se" => {
+            // Northern Sami
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "nn" => {
+            // Norwegian Nynorsk
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "no" => {
+            // Norwegian (old code)
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "nso" => {
+            // Northern Sotho
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+
+        "oc" => {
+            // Occitan
+            if n > 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "or" => {
+            // Oriya
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+
+        "ps" => {
+            // Pashto
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "pa" => {
+            // Punjabi
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "pap" => {
+            // Papiamento
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "pl" => {
+            // Polish
+            if n == 0 {
+                0
+            } else if n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 10 || n % 100 >= 20) {
+                1
+            } else {
+                2
+            }
+        }
+        "pms" => {
+            // Piemontese
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "pt" => {
+            // Portuguese
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "pt-br" => {
+            // Brazilian Portuguese
+            if n > 1 {
+                1
+            } else {
+                0
+            }
+        }
+
+        "rm" => {
+            // Romansh
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "ro" => {
+            // Romanian
+            if n == 1 {
+                0
+            } else if n == 0 || (n % 100 > 0 && n % 100 < 20) {
+                1
+            } else {
+                2
+            }
+        }
+        "ru" => {
+            // Russian
+            if n % 10 == 1 && n % 100 != 11 {
+                0
+            } else if n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 10 || n % 100 >= 20) {
+                1
+            } else {
+                2
+            }
+        }
+
+        "sco" => {
+            // Scots
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "si" => {
+            // Sinhala
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "sk" => {
+            // Slovak
+            if n == 1 {
+                0
+            } else if n >= 2 && n <= 4 {
+                1
+            } else {
+                2
+            }
+        }
+        "sl" => {
+            // Slovenian
+            if n % 100 == 1 {
+                1
+            } else if n % 100 == 2 {
+                2
+            } else if n % 100 == 3 || n % 100 == 4 {
+                3
+            } else {
+                0
+            }
+        }
+        "so" => {
+            // Somali
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "son" => {
+            // Songhay
+            0
+        }
+        "sq" => {
+            // Albanian
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "sr" => {
+            // Serbian
+            if n % 10 == 1 && n % 100 != 11 {
+                0
+            } else if n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 10 || n % 100 >= 20) {
+                1
+            } else {
+                2
+            }
+        }
+        "su" => {
+            // Sundanese
+            0
+        }
+        "sw" => {
+            // Swahili
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "sv" => {
+            // Swedish
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+
+        "ta" => {
+            // Tamil
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "te" => {
+            // Telugu
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "tg" => {
+            // Tajik
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "ti" => {
+            // Tigrinya
+            if n > 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "th" => {
+            // Thai
+            0
+        }
+        "tk" => {
+            // Turkmen
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "tr" => {
+            // Turkish
+            0
+        }
+        "tt" => {
+            // Tatar
+            0
+        }
+
+        "ug" => {
+            // Uyghur
+            0
+        }
+        "uk" => {
+            // Ukrainian
+            if n % 10 == 1 && n % 100 != 11 {
+                0
+            } else if n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 10 || n % 100 >= 20) {
+                1
+            } else {
+                2
+            }
+        }
+        "ur" => {
+            // Urdu
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+        "uz" => {
+            // Uzbek
+            0
+        }
+
+        "vi" => {
+            // Vietnamese
+            0
+        }
+
+        "wa" => {
+            // Walloon
+            if n > 1 {
+                1
+            } else {
+                0
+            }
+        }
+
+        "zh" => {
+            // Chinese
+            0
+        }
+        "zh-personal" => {
+            // Chinese, used in special cases when dealing with personal pronoun
+            if n > 1 {
+                1
+            } else {
+                0
+            }
+        }
+        _ => {
+            if n != 1 {
+                1
+            } else {
+                0
+            }
+        }
+    }
+}

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -1,0 +1,34 @@
+// Copyright (C) 2020 Julen Ruiz Aizpuru, https://github.com/julen
+
+/// Splits a string `s` upon the `start` and `end` delimiters.
+/// Returns a vector of owned strings.
+/// NOTE: this is needed because `regex::Regex::split()` doesn't capture groups
+/// (cf. rust-lang/regex#285).
+pub(crate) fn split_string(s: &str, start: &str, end: &str) -> Vec<String> {
+    let mut delim = false;
+    let mut accum = "".to_string();
+    let mut out: Vec<String> = vec![];
+
+    for _char in s.chars() {
+        let ch = _char.to_string();
+        if (ch == start || ch == end) == delim {
+            if delim {
+                if accum != "" {
+                    out.push(accum);
+                }
+                accum = ch;
+            } else {
+                accum.push_str(&ch);
+            }
+        } else {
+            out.push(accum);
+            delim = !delim;
+            accum = ch;
+        }
+    }
+
+    if accum != "" {
+        out.push(accum);
+    }
+    out
+}

--- a/rust/tests/test_format.rs
+++ b/rust/tests/test_format.rs
@@ -1,0 +1,187 @@
+// Copyright (C) 2020 Julen Ruiz Aizpuru, https://github.com/julen
+
+extern crate plurr;
+
+use plurr::{Plurr, PlurrError};
+
+#[test]
+fn format_error_unmatched_braces() {
+    let mut p = Plurr::new();
+
+    let result_opening = p.format("err {");
+    assert!(result_opening.is_err());
+    assert_eq!(result_opening, Err(PlurrError::UnmatchedOpeningBrace));
+
+    let result_closing = p.format("err }");
+    assert!(result_closing.is_err());
+    assert_eq!(result_closing, Err(PlurrError::UnmatchedClosingBrace));
+}
+
+#[test]
+fn format_error_param_undefined() {
+    let mut p = Plurr::new();
+
+    let result = p.format("{foo}");
+    assert!(result.is_err());
+    assert_eq!(result, Err(PlurrError::UndefinedParameter));
+}
+
+#[test]
+fn format_error_empty_placeholder() {
+    let mut p = Plurr::new();
+
+    let s = "Delete {:{N} file|{N} files}?";
+    assert_eq!(
+        p.param("N", "2").format(s),
+        Err(PlurrError::EmptyPlaceholder)
+    )
+}
+
+#[test]
+fn format_n_plural() {
+    let mut p = Plurr::new();
+    let s = "Do you want to delete {N_PLURAL:this {N} file|these {N} files} permanently?";
+
+    assert_eq!(
+        p.param("N", "1").format(s),
+        Ok("Do you want to delete this 1 file permanently?".to_string())
+    );
+
+    assert_eq!(
+        p.param("N", "5").format(s),
+        Ok("Do you want to delete these 5 files permanently?".to_string())
+    );
+}
+
+#[test]
+fn format_no_auto_plurals() {
+    let mut p = Plurr::new();
+    p.auto_plurals(false);
+    let s = "Do you want to delete {N_PLURAL:this {N} file|these {N} files} permanently?";
+
+    assert_eq!(
+        p.param("N", "1").format(s),
+        Err(PlurrError::UndefinedParameter)
+    );
+    assert_eq!(
+        p.param("N_PLURAL", "0").param("N", "1").format(s),
+        Ok("Do you want to delete this 1 file permanently?".to_string())
+    );
+    assert_eq!(
+        p.param("N_PLURAL", "1").param("N", "5").format(s),
+        Ok("Do you want to delete these 5 files permanently?".to_string())
+    );
+}
+
+#[test]
+fn format_not_zero_or_positive_args() {
+    let mut p = Plurr::new();
+    let s = "{N_PLURAL:One file|{N} files}";
+
+    assert_eq!(
+        p.param("N", "-1").format(s),
+        Err(PlurrError::NotZeroOrPositiveValue)
+    );
+    assert_eq!(
+        p.param("N", "Hello").format(s),
+        Err(PlurrError::NotZeroOrPositiveValue)
+    );
+}
+
+#[test]
+fn format_arbitrary_arg() {
+    let mut p = Plurr::new();
+
+    let s = "Do you want to drink {CHOICE:coffee|tea|juice}?";
+
+    assert_eq!(
+        p.param("CHOICE", "0").format(s),
+        Ok("Do you want to drink coffee?".to_string())
+    );
+    assert_eq!(
+        p.param("CHOICE", "1").format(s),
+        Ok("Do you want to drink tea?".to_string())
+    );
+    assert_eq!(
+        p.param("CHOICE", "2").format(s),
+        Ok("Do you want to drink juice?".to_string())
+    );
+    // when out of bounds, last form is used
+    assert_eq!(
+        p.param("CHOICE", "5").format(s),
+        Ok("Do you want to drink juice?".to_string())
+    );
+}
+
+#[test]
+fn format_locale_arg() {
+    let mut p = Plurr::new();
+
+    let s = "Удалить {N_PLURAL:этот {N} файл|эти {N} файла|эти {N} файлов} навсегда?";
+    assert_eq!(
+        p.locale("ru").param("N", "1").format(s),
+        Ok("Удалить этот 1 файл навсегда?".to_string())
+    );
+    assert_eq!(
+        p.locale("ru").param("N", "2").format(s),
+        Ok("Удалить эти 2 файла навсегда?".to_string())
+    );
+    assert_eq!(
+        p.locale("ru").param("N", "5").format(s),
+        Ok("Удалить эти 5 файлов навсегда?".to_string())
+    );
+}
+
+#[test]
+fn format_nested() {
+    let mut p = Plurr::new();
+
+    let s = "{X_PLURAL:{X:|One|{X}} file|{X:No|{X}} files} found.";
+
+    assert_eq!(
+        p.param("X", "0").format(s),
+        Ok("No files found.".to_string())
+    );
+    assert_eq!(
+        p.param("X", "1").format(s),
+        Ok("One file found.".to_string())
+    );
+    assert_eq!(
+        p.param("X", "2").format(s),
+        Ok("2 files found.".to_string())
+    );
+}
+
+#[test]
+fn format_nested_locale() {
+    let mut p = Plurr::new();
+    let s =
+        "{X_PLURAL:Найден {X:|один|{X}} файл|Найдены {X} файла|{X:Не найдено|Найдено {X}} файлов}.";
+
+    assert_eq!(
+        p.locale("ru").param("X", "0").format(s),
+        Ok("Не найдено файлов.".to_string())
+    );
+    assert_eq!(
+        p.locale("ru").param("X", "1").format(s),
+        Ok("Найден один файл.".to_string())
+    );
+    assert_eq!(
+        p.locale("ru").param("X", "2").format(s),
+        Ok("Найдены 2 файла.".to_string())
+    );
+    assert_eq!(
+        p.locale("ru").param("X", "5").format(s),
+        Ok("Найдено 5 файлов.".to_string())
+    );
+}
+
+#[test]
+fn format_args() {
+    let mut p = Plurr::new();
+    let s = "{FOO}";
+
+    assert_eq!(p.param("FOO", "1").format(s), Ok("1".to_string()));
+    assert_eq!(p.param("FOO", "5.5").format(s), Ok("5.5".to_string()));
+    assert_eq!(p.param("FOO", "bar").format(s), Ok("bar".to_string()));
+}


### PR DESCRIPTION
The implementation tries to stay as close to the original code as
possible, although due to the nature of the language, some constructs
are not possible, and different idioms/expressions must be used, e.g.
pattern matching via `match`.

This also affects the API, because in Rust there's no way (yet) to
provide optional arguments, and string-formatting parameters are
therefore fed via `.param("key", "value")` pairs. To keep things simple,
this only accepts strings for the time being.

Likewise, a macro could be written to support a `format` call with
variadic arguments, but that's left as a potential future improvement.

The tests include all syntax features, and also potential formatting
errors.