### PR TITLE
Plural equations: fix return values

### DIFF
--- a/js/plurr.js
+++ b/js/plurr.js
@@ -97,7 +97,7 @@
 
       'ia': function(n) { return (n!=1) ? 1 : 0; }, // Interlingua
       'id': function(n) { return 0; }, // Indonesian
-      'is': function(n) { return (n%10!=1 || n%100==11); }, // Icelandic
+      'is': function(n) { return (n%10!=1 || n%100==11) ? 1 : 0; }, // Icelandic
       'it': function(n) { return (n!=1) ? 1 : 0; }, // Italian
 
       'ja': function(n) { return 0; }, // Japanese
@@ -112,7 +112,7 @@
       'kw': function(n) { return (n==1) ? 0 : (n==2) ? 1 : (n==3) ? 2 : 3; }, // Cornish
       'ky': function(n) { return 0; }, // Kyrgyz
 
-      'lb': function(n) { return (n!=1); }, // Letzeburgesch
+      'lb': function(n) { return (n!=1) ? 1 : 0; }, // Letzeburgesch
       'ln': function(n) { return (n>1) ? 1 : 0; }, // Lingala
       'lo': function(n) { return 0; }, // Lao
       'lt': function(n) { return (n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 || n%100>=20) ? 1 : 2); }, // Lithuanian
@@ -149,7 +149,7 @@
       'pt': function(n) { return (n!=1) ? 1 : 0; }, // Portuguese
       'pt-br': function(n) { return (n>1) ? 1 : 0; }, // Brazilian Portuguese
 
-      'rm': function(n) { return (n!=1); }, // Romansh
+      'rm': function(n) { return (n!=1) ? 1 : 0; }, // Romansh
       'ro': function(n) { return (n==1 ? 0 : (n==0 || (n%100>0 && n%100<20)) ? 1 : 2); }, // Romanian
       'ru': function(n) { return (n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2); }, // Russian
 

--- a/obj-c/Plurr.m
+++ b/obj-c/Plurr.m
@@ -511,7 +511,7 @@ static NSString* const kPluralSuffix = @"_PLURAL";
 }
 // Icelandic
 - (NSUInteger)pluralVariationsForCount_is: (NSUInteger)n {
-  return (n%10!=1 || n%100==11);
+  return (n%10!=1 || n%100==11) ? 1 : 0;
 }
 // Italian
 - (NSUInteger)pluralVariationsForCount_it: (NSUInteger)n {
@@ -562,7 +562,7 @@ static NSString* const kPluralSuffix = @"_PLURAL";
 
 // Letzeburgesch
 - (NSUInteger)pluralVariationsForCount_lb: (NSUInteger)n {
-  return (n!=1);
+  return (n!=1) ? 1 : 0;
 }
 // Lingala
 - (NSUInteger)pluralVariationsForCount_ln: (NSUInteger)n {
@@ -695,7 +695,7 @@ static NSString* const kPluralSuffix = @"_PLURAL";
 
 // Romansh
 - (NSUInteger)pluralVariationsForCount_rm: (NSUInteger)n {
-  return (n!=1);
+  return (n!=1) ? 1 : 0;
 }
 // Romanian
 - (NSUInteger)pluralVariationsForCount_ro: (NSUInteger)n {

--- a/perl/Plurr.pm
+++ b/perl/Plurr.pm
@@ -104,7 +104,7 @@ my $_plural_equations = {
 
   'ia' => sub { my $n = shift; return ($n!=1) ? 1 : 0; }, # Interlingua
   'id' => sub { my $n = shift; return 0; }, # Indonesian
-  'is' => sub { my $n = shift; return ($n%10!=1 || $n%100==11); }, # Icelandic
+  'is' => sub { my $n = shift; return ($n%10!=1 || $n%100==11) ? 1 : 0; }, # Icelandic
   'it' => sub { my $n = shift; return ($n!=1) ? 1 : 0; }, # Italian
 
   'ja' => sub { my $n = shift; return 0; }, # Japanese
@@ -119,7 +119,7 @@ my $_plural_equations = {
   'kw' => sub { my $n = shift; return ($n==1) ? 0 : ($n==2) ? 1 : ($n==3) ? 2 : 3; }, # Cornish
   'ky' => sub { my $n = shift; return 0; }, # Kyrgyz
 
-  'lb' => sub { my $n = shift; return ($n!=1); }, # Letzeburgesch
+  'lb' => sub { my $n = shift; return ($n!=1) ? 1 : 0; }, # Letzeburgesch
   'ln' => sub { my $n = shift; return ($n>1) ? 1 : 0; }, # Lingala
   'lo' => sub { my $n = shift; return 0; }, # Lao
   'lt' => sub { my $n = shift; return ($n%10==1 && $n%100!=11 ? 0 : $n%10>=2 && ($n%100<10 || $n%100>=20) ? 1 : 2); }, # Lithuanian
@@ -156,7 +156,7 @@ my $_plural_equations = {
   'pt' => sub { my $n = shift; return ($n!=1) ? 1 : 0; }, # Portuguese
   'pt-br' => sub { my $n = shift; return ($n>1) ? 1 : 0; }, # Brazilian Portuguese
 
-  'rm' => sub { my $n = shift; return ($n!=1); }, # Romansh
+  'rm' => sub { my $n = shift; return ($n!=1) ? 1 : 0; }, # Romansh
   'ro' => sub { my $n = shift; return ($n==1 ? 0 : ($n==0 || ($n%100>0 && $n%100<20)) ? 1 : 2); }, # Romanian
   'ru' => sub { my $n = shift; return ($n%10==1 && $n%100!=11 ? 0 : $n%10>=2 && $n%10<=4 && ($n%100<10 || $n%100>=20) ? 1 : 2); }, # Russian
 

--- a/php/Plurr.php
+++ b/php/Plurr.php
@@ -84,7 +84,7 @@ class Plurr {
 
       'ia' => function ($n) { return ($n!=1) ? 1 : 0; }, // Interlingua
       'id' => function ($n) { return 0; }, // Indonesian
-      'is' => function ($n) { return ($n%10!=1 || $n%100==11); }, // Icelandic
+      'is' => function ($n) { return ($n%10!=1 || $n%100==11) ? 1 : 0; }, // Icelandic
       'it' => function ($n) { return ($n!=1) ? 1 : 0; }, // Italian
 
       'ja' => function ($n) { return 0; }, // Japanese
@@ -99,7 +99,7 @@ class Plurr {
       'kw' => function ($n) { return ($n==1) ? 0 : (($n==2) ? 1 : (($n==3) ? 2 : 3)); }, // Cornish
       'ky' => function ($n) { return 0; }, // Kyrgyz
 
-      'lb' => function ($n) { return ($n!=1); }, // Letzeburgesch
+      'lb' => function ($n) { return ($n!=1) ? 1 : 0; }, // Letzeburgesch
       'ln' => function ($n) { return ($n>1) ? 1 : 0; }, // Lingala
       'lo' => function ($n) { return 0; }, // Lao
       'lt' => function ($n) { return ($n%10==1 && $n%100!=11 ? 0 : ($n%10>=2 && ($n%100<10 || $n%100>=20) ? 1 : 2)); }, // Lithuanian
@@ -136,7 +136,7 @@ class Plurr {
       'pt' => function ($n) { return ($n!=1) ? 1 : 0; }, // Portuguese
       'pt-br' => function ($n) { return ($n>1) ? 1 : 0; }, // Brazilian Portuguese
 
-      'rm' => function ($n) { return ($n!=1); }, // Romansh
+      'rm' => function ($n) { return ($n!=1) ? 1 : 0; }, // Romansh
       'ro' => function ($n) { return ($n==1 ? 0 : ($n==0 || ($n%100>0 && $n%100<20)) ? 1 : 2); }, // Romanian
       'ru' => function ($n) { return ($n%10==1 && $n%100!=11 ? 0 : ($n%10>=2 && $n%10<=4 && ($n%100<10 || $n%100>=20) ? 1 : 2)); }, // Russian
 

--- a/python/plurr.py
+++ b/python/plurr.py
@@ -82,7 +82,7 @@ class Plurr(object):
 
         'ia': lambda n: 1 if (n!=1) else 0,  # Interlingua
         'id': lambda n: 0,  # Indonesian
-        'is': lambda n: (n%10!=1 or n%100==11),  # Icelandic
+        'is': lambda n: 1 if (n%10!=1 or n%100==11) else 0,  # Icelandic
         'it': lambda n: 1 if (n!=1) else 0,  # Italian
 
         'ja': lambda n: 0,  # Japanese
@@ -97,7 +97,7 @@ class Plurr(object):
         'kw': lambda n: 0 if (n==1) else 1 if (n==2) else 2 if (n==3) else 3,  # Cornish
         'ky': lambda n: 0,  # Kyrgyz
 
-        'lb': lambda n: (n!=1),  # Letzeburgesch
+        'lb': lambda n: 1 if (n!=1) else 0,  # Letzeburgesch
         'ln': lambda n: 1 if (n>1) else 0,  # Lingala
         'lo': lambda n: 0,  # Lao
         'lt': lambda n: 0 if n%10==1 and n%100!=11 else 1 if n%10>=2 and (n%100<10 or n%100>=20) else 2,  # Lithuanian
@@ -134,7 +134,7 @@ class Plurr(object):
         'pt': lambda n: 1 if (n!=1) else 0,  # Portuguese
         'pt-br': lambda n: 1 if (n>1) else 0,  # Brazilian Portuguese
 
-        'rm': lambda n: (n!=1),  # Romansh
+        'rm': lambda n: 1 if (n!=1) else 0,  # Romansh
         'ro': lambda n: 0 if n==1 else 1 if (n==0 or (n%100>0 and n%100<20)) else 2,  # Romanian
         'ru': lambda n: 0 if n%10==1 and n%100!=11 else 1 if n%10>=2 and n%10<=4 and (n%100<10 or n%100>=20) else 2,  # Russian
 


### PR DESCRIPTION
Some plural equations were returning booleans instead of integers.

Affected locales: 'is', 'lb', and 'rm'.
Affected implementations: JavaScript, Objective-C, Perl, PHP, Python.