### PR TITLE
Rust implementation followup fixes

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -25,23 +25,23 @@ pub enum PlurrError {
 type PlurrParams = HashMap<String, String>;
 
 #[derive(Debug)]
-pub struct Plurr {
-    locale: String,
+pub struct Plurr<'a> {
+    locale: &'a str,
     auto_plurals: bool,
     strict: bool,
     params: PlurrParams,
 }
 
-impl Default for Plurr {
+impl<'a> Default for Plurr<'a> {
     fn default() -> Self {
         Plurr::new()
     }
 }
 
-impl Plurr {
+impl<'a> Plurr<'a> {
     pub fn new() -> Self {
         Plurr {
-            locale: "en".to_string(),
+            locale: "en",
             auto_plurals: true,
             strict: true,
             params: PlurrParams::new(),
@@ -50,8 +50,8 @@ impl Plurr {
 
     /// Sets the locale for Plurr. If this is not called or an incompatible
     /// `locale_code` is provided, it defaults to English.
-    pub fn locale(&mut self, locale_code: &str) -> &mut Plurr {
-        self.locale = locale_code.to_string();
+    pub fn locale(&mut self, locale_code: &'a str) -> &mut Plurr<'a> {
+        self.locale = locale_code;
         self
     }
 
@@ -60,20 +60,20 @@ impl Plurr {
     /// the current locale.
     /// * Without auto-plurals, you will need to manually provide an `N_PLURAL`
     /// parameter before calling `format()`.
-    pub fn auto_plurals(&mut self, auto_plurals: bool) -> &mut Plurr {
+    pub fn auto_plurals(&mut self, auto_plurals: bool) -> &mut Plurr<'a> {
         self.auto_plurals = auto_plurals;
         self
     }
 
     /// Toggles strict mode. In strict mode, errors are not skipped.
-    pub fn strict(&mut self, strict: bool) -> &mut Plurr {
+    pub fn strict(&mut self, strict: bool) -> &mut Plurr<'a> {
         self.strict = strict;
         self
     }
 
     /// Stores a parameter value. Parameters must be fed before calling
     /// `format()`.
-    pub fn param(&mut self, key: &str, value: &str) -> &mut Plurr {
+    pub fn param(&mut self, key: &str, value: &str) -> &mut Plurr<'a> {
         self.params.insert(key.to_string(), value.to_string());
         self
     }

--- a/rust/tests/test_format.rs
+++ b/rust/tests/test_format.rs
@@ -9,11 +9,9 @@ fn format_error_unmatched_braces() {
     let mut p = Plurr::new();
 
     let result_opening = p.format("err {");
-    assert!(result_opening.is_err());
     assert_eq!(result_opening, Err(PlurrError::UnmatchedOpeningBrace));
 
     let result_closing = p.format("err }");
-    assert!(result_closing.is_err());
     assert_eq!(result_closing, Err(PlurrError::UnmatchedClosingBrace));
 }
 
@@ -22,7 +20,6 @@ fn format_error_param_undefined() {
     let mut p = Plurr::new();
 
     let result = p.format("{foo}");
-    assert!(result.is_err());
     assert_eq!(result, Err(PlurrError::UndefinedParameter));
 }
 


### PR DESCRIPTION
* Remove unneeded test assertions
* Store locale as an `str` pointer