### PR TITLE
Rust improvements

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plurr"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Julen Ruiz Aizpuru <julenx@gmail.com>"]
 edition = "2018"
 description = "A library for handling plurals/genders/conditionals."

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -40,7 +40,7 @@ impl<'a> Default for Plurr<'a> {
 
 impl<'a> Plurr<'a> {
     pub fn new() -> Self {
-        Plurr {
+        Self {
             locale: "en",
             auto_plurals: true,
             strict: true,
@@ -50,7 +50,7 @@ impl<'a> Plurr<'a> {
 
     /// Sets the locale for Plurr. If this is not called or an incompatible
     /// `locale_code` is provided, it defaults to English.
-    pub fn locale(&mut self, locale_code: &'a str) -> &mut Plurr<'a> {
+    pub fn locale(&mut self, locale_code: &'a str) -> &mut Self {
         self.locale = locale_code;
         self
     }
@@ -60,20 +60,20 @@ impl<'a> Plurr<'a> {
     /// the current locale.
     /// * Without auto-plurals, you will need to manually provide an `N_PLURAL`
     /// parameter before calling `format()`.
-    pub fn auto_plurals(&mut self, auto_plurals: bool) -> &mut Plurr<'a> {
+    pub fn auto_plurals(&mut self, auto_plurals: bool) -> &mut Self {
         self.auto_plurals = auto_plurals;
         self
     }
 
     /// Toggles strict mode. In strict mode, errors are not skipped.
-    pub fn strict(&mut self, strict: bool) -> &mut Plurr<'a> {
+    pub fn strict(&mut self, strict: bool) -> &mut Self {
         self.strict = strict;
         self
     }
 
     /// Stores a parameter value. Parameters must be fed before calling
     /// `format()`.
-    pub fn param(&mut self, key: &str, value: &str) -> &mut Plurr<'a> {
+    pub fn param(&mut self, key: &str, value: &str) -> &mut Self {
         self.params.insert(key.to_string(), value.to_string());
         self
     }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -73,7 +73,7 @@ impl<'a> Plurr<'a> {
 
     /// Stores a parameter value. Parameters must be fed before calling
     /// `format()`.
-    pub fn param(&mut self, key: &str, value: &str) -> &mut Self {
+    pub fn param<T: ToString>(&mut self, key: &str, value: T) -> &mut Self {
         self.params.insert(key.to_string(), value.to_string());
         self
     }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -122,13 +122,13 @@ impl<'a> Plurr<'a> {
                             return Err(PlurrError::EmptyPlaceholder);
                         }
                         // Multiple choices
-                        block[0..colon_pos].to_string()
+                        &block[0..colon_pos]
                     }
                     // Simple placeholder
-                    None => block.to_owned(),
+                    None => &block,
                 };
 
-                if !self.params.contains_key(&name) {
+                if !self.params.contains_key(name) {
                     let p_pos = name.find(_PLURAL);
                     if self.auto_plurals
                         && p_pos.is_some()
@@ -153,7 +153,7 @@ impl<'a> Plurr<'a> {
                         }
 
                         self.params.insert(
-                            name.clone(),
+                            name.to_owned(),
                             plurals::plural_func(&self.locale, prefix_value).to_string(),
                         );
                     } else if self.strict {
@@ -170,7 +170,7 @@ impl<'a> Plurr<'a> {
                             return Err(PlurrError::EmptyVariants);
                         }
 
-                        let value = self.params.get(&name).unwrap();
+                        let value = self.params.get(name).unwrap();
                         let mut choice_idx: usize = value.parse().unwrap_or(0);
 
                         let content_start = colon_pos + 1;
@@ -182,7 +182,7 @@ impl<'a> Plurr<'a> {
                         }
                         parts[choice_idx]
                     }
-                    None => self.params.get(&name).unwrap(),
+                    None => self.params.get(name).unwrap(),
                 };
 
                 let index = blocks.len() - 1;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -141,16 +141,15 @@ impl<'a> Plurr<'a> {
 
                         // This is where the actual parameter replacing happens
                         let prefix_value_maybe = self.params.get(&prefix).unwrap();
-                        let prefix_value;
-                        match prefix_value_maybe.parse::<usize>() {
-                            Ok(parsed_value) => prefix_value = parsed_value,
+                        let prefix_value = match prefix_value_maybe.parse::<usize>() {
+                            Ok(parsed_value) => parsed_value,
                             Err(_) => {
                                 if self.strict {
                                     return Err(PlurrError::NotZeroOrPositiveValue);
                                 }
-                                prefix_value = 0;
+                                0
                             }
-                        }
+                        };
 
                         self.params.insert(
                             name.to_owned(),

--- a/rust/tests/test_format.rs
+++ b/rust/tests/test_format.rs
@@ -182,3 +182,19 @@ fn format_args() {
     assert_eq!(p.param("FOO", "5.5").format(s), Ok("5.5".to_string()));
     assert_eq!(p.param("FOO", "bar").format(s), Ok("bar".to_string()));
 }
+
+#[test]
+fn format_no_str_args() {
+    let mut p = Plurr::new();
+    let s = "{FOO}";
+
+    use std::net::Ipv4Addr;
+    let localhost = Ipv4Addr::new(127, 0, 0, 1);
+
+    assert_eq!(p.param("FOO", 1).format(s), Ok("1".to_string()));
+    assert_eq!(p.param("FOO", 5.5).format(s), Ok("5.5".to_string()));
+    assert_eq!(
+        p.param("FOO", localhost).format(s),
+        Ok("127.0.0.1".to_string())
+    );
+}


### PR DESCRIPTION
* Now parameters can be of any type as long as they can be converted to string via the `ToString` trait
* Avoids some string allocations
* Reduces some nesting by using idiomatic `if let...` constructs